### PR TITLE
ドロワーのサイズの変更

### DIFF
--- a/app/components/Drawer/index.js
+++ b/app/components/Drawer/index.js
@@ -21,7 +21,7 @@ class Drawer extends React.PureComponent<DefaultProps, Props, void> {
   props: Props
 
   static defaultProps: DefaultProps = {
-    width: 600,
+    width: 500,
   }
 
   handleKeyUp = handleEscCreater(this.props.onRequestClose)


### PR DESCRIPTION
600→500
600だとサイズが大きすぎた。

縦長の画像が多いので、500で十分そう