### PR TITLE
カラムの並び替えの保存

### DIFF
--- a/app/containers/ColumnFollow/reducer.js
+++ b/app/containers/ColumnFollow/reducer.js
@@ -1,9 +1,9 @@
 // @flow
 import update from 'utils/update'
+import { REHYDRATE } from 'redux-persist/constants'
 import { handleRehydrate } from 'utils/handleReydrate'
 import type { Action } from './actionTypes'
 import * as Actions from './constants'
-import { REHYDRATE } from 'redux-persist/constants'
 
 export type Restrict = 'public' | 'private'
 

--- a/app/containers/Table/Table.js
+++ b/app/containers/Table/Table.js
@@ -1,19 +1,25 @@
 // @flow
 import React from 'react'
 import { SortablePane, Pane } from 'react-sortable-pane'
-import ColumnManager, {
-  type Props as ManegerProps,
-} from 'containers/ColumnManager'
+import ColumnManager from '../ColumnManager'
+import type { TableIds } from './reducer'
+import typeof { setTable } from './actions'
 
 export type Props = {
-  ids: Array<$PropertyType<ManegerProps, 'id'>>,
+  ids: TableIds,
+  setTabel: setTable,
 }
 
-const Table = ({ ids }: Props) => {
+const Table = ({ ids, setTabel }: Props) => {
   const handleOnResize = () => null
 
   if (ids.length === 0) {
     return null
+  }
+
+  const handleOrderChange = (_, panes) => {
+    const newState = panes.map(v => v.id)
+    setTabel(newState)
   }
 
   const panes = ids.map(id =>
@@ -29,7 +35,11 @@ const Table = ({ ids }: Props) => {
   )
 
   return (
-    <SortablePane disableEffect onResize={handleOnResize}>
+    <SortablePane
+      disableEffect
+      onResize={handleOnResize}
+      onOrderChange={handleOrderChange}
+    >
       {panes}
     </SortablePane>
   )

--- a/app/containers/Table/actionTypes.js
+++ b/app/containers/Table/actionTypes.js
@@ -1,8 +1,14 @@
 // @flow
 export type ADD_TABLE_TYPE = 'Table/ADD_TABLE'
 export type REMOVE_TABLE_TYPE = 'Table/REMOVE_TABLE'
+export type SET_TABLE_TYPE = 'Table/SET_TABLE_TYPE'
 
-export type Action = {|
-  +type: ADD_TABLE_TYPE | REMOVE_TABLE_TYPE,
-  +id: string,
-|}
+export type Action =
+  | {|
+      +type: ADD_TABLE_TYPE | REMOVE_TABLE_TYPE,
+      +id: string,
+    |}
+  | {
+      +type: SET_TABLE_TYPE,
+      +ids: Array<string>,
+    }

--- a/app/containers/Table/actions.js
+++ b/app/containers/Table/actions.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Action } from './actionTypes.js'
-import { ADD_TABLE, REMOVE_TABLE } from './constants'
+import { ADD_TABLE, REMOVE_TABLE, SET_TABLE } from './constants'
 
 export function addTable(id: string): Action {
   return {
@@ -13,5 +13,12 @@ export function removeTable(id: string): Action {
   return {
     type: REMOVE_TABLE,
     id,
+  }
+}
+
+export function setTable(ids: Array<string>): Action {
+  return {
+    type: SET_TABLE,
+    ids,
   }
 }

--- a/app/containers/Table/constants.js
+++ b/app/containers/Table/constants.js
@@ -1,5 +1,10 @@
 // @flow
-import type { ADD_TABLE_TYPE, REMOVE_TABLE_TYPE } from './actionTypes.js'
+import type {
+  ADD_TABLE_TYPE,
+  REMOVE_TABLE_TYPE,
+  SET_TABLE_TYPE,
+} from './actionTypes.js'
 
 export const ADD_TABLE: ADD_TABLE_TYPE = 'Table/ADD_TABLE'
 export const REMOVE_TABLE: REMOVE_TABLE_TYPE = 'Table/REMOVE_TABLE'
+export const SET_TABLE: SET_TABLE_TYPE = 'Table/SET_TABLE_TYPE'

--- a/app/containers/Table/index.js
+++ b/app/containers/Table/index.js
@@ -3,10 +3,23 @@ import { connect, type Connector } from 'react-redux'
 import { createStructuredSelector } from 'reselect'
 import Tabel, { type Props } from './Table'
 import { makeSelectIds } from './selectors'
+import type { TableIds } from './reducer'
+import * as actions from './actions'
 
 const mapStateToProps = createStructuredSelector({
   ids: makeSelectIds(),
 })
 
-const connector: Connector<{}, Props> = connect(mapStateToProps)
+const mapDispatchToProps = (dispatch: Dispatch) => {
+  return {
+    setTabel(ids: TableIds) {
+      dispatch(actions.setTable(ids))
+    },
+  }
+}
+
+const connector: Connector<{}, Props> = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)
 export default connector(Tabel)

--- a/app/containers/Table/reducer.js
+++ b/app/containers/Table/reducer.js
@@ -1,15 +1,20 @@
 // @flow
 import { union } from 'lodash'
+import { REHYDRATE } from 'redux-persist/constants'
 import type { ColumnManagerId } from '../ColumnManager/reducer'
 import type { Action } from './actionTypes'
 import * as Actions from './constants'
 
+export type TableIds = Array<ColumnManagerId>
+
 export type State = {
-  ids: Array<ColumnManagerId>,
+  ids: TableIds,
+  nextIds: TableIds,
 }
 
 const initialState: State = {
   ids: [],
+  nextIds: [],
 }
 
 export default function(
@@ -18,9 +23,31 @@ export default function(
 ): $Shape<State> {
   switch (action.type) {
     case Actions.ADD_TABLE:
-      return { ids: union(state.ids, [action.id]) }
-    case Actions.REMOVE_TABLE:
-      return { ids: state.ids.filter(v => action.id !== v) }
+      return {
+        ids: union(state.ids, [action.id]),
+        nextIds: union(state.nextIds, [action.id]),
+      }
+
+    case Actions.REMOVE_TABLE: {
+      const id = action.id
+      return {
+        ids: state.ids.filter(v => id !== v),
+        nextIds: state.ids.filter(v => id !== v),
+      }
+    }
+
+    case Actions.SET_TABLE:
+      return { ...state, nextIds: action.ids }
+
+    case REHYDRATE: {
+      // $FlowFixMe
+      const oldState: State = action.payload.Table
+      if (oldState) {
+        return { ids: oldState.nextIds, nextIds: [] }
+      }
+      return state
+    }
+
     default:
       return state
   }


### PR DESCRIPTION
close #24

カラム自体は場所の情報を持たない。
カラムを管理するTableがカラムの順序を保持する

redux-persistの再構成時に、保存しておいた順序で復元すること。

ちょっとreducerが汚い。要リファクタ