### PR TITLE
Update builder settings for windows

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -32,5 +32,5 @@ win:
     - nsis
     - zip
     - 7z
-# nsis:
-  # perMachine: true
+nsis:
+  allowToChangeInstallationDirectory: true


### PR DESCRIPTION
## Why?
Windows環境においてインストール先を任意に選択可能にする。

related #111 