### PR TITLE
Set NSIS installer setting

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,4 +33,5 @@ win:
     - zip
     - 7z
 nsis:
+  oneClick: false
   allowToChangeInstallationDirectory: true


### PR DESCRIPTION
related #113 

## Why

```
Error: allowToChangeInstallationDirectory makes sense only for boring installer (please set oneClick to false)
```

