### PR TITLE
Fix appvoyer.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - ps: Install-Product node 8.5 x64
+  - ps: Install-Product node 8 x64
   - yarn
   - npm install electron-builder@next --dev # force install next version to test electron-builder
 


### PR DESCRIPTION
Related #137 

appvoyerのnodeバージョンを指定を修正。
これをマージののちv0.16.2をリリースしCIが動いているかを確認する。